### PR TITLE
Fix potential NaN issue in percent calculation

### DIFF
--- a/fs_usage.go
+++ b/fs_usage.go
@@ -53,11 +53,18 @@ func FSUsage(path string) FSInfo {
 	avail := uint64(stat.f_bavail)
 	free := uint64(stat.f_bfree)
 
+        var usedPercent float64
+        if blocks == 0 || frsize == 0 {
+		usedPercent = 100
+	} else {
+		usedPercent = (100 * float64(free*frsize) / float64(blocks*frsize))
+        }
+
 	return FSInfo{
 		Free:     free * frsize,
 		Avail:    avail * frsize,
 		Blocks:   blocks * frsize,
 		ReadOnly: readonly == 1,
-		Percent:  100 - (100 * float64(free*frsize) / float64(blocks*frsize)),
+		Percent:  100 - usedPercent,
 	}
 }


### PR DESCRIPTION
As previously calculated the Percent value of FSInfo could be NaN because of a divide by zero issue.  I observed this on a real system.

To fix this, calculate the used percent and set it to 100 if blocks or frsize is 0.  This eliminates the potential divide by zero issue and sets the free percent to 0 in this case.